### PR TITLE
🐛 Fix: 言語切り替えボタンが正しく動作しない問題を修正

### DIFF
--- a/src/components/Layout/AppLayout.tsx
+++ b/src/components/Layout/AppLayout.tsx
@@ -25,6 +25,7 @@ import { motion } from "framer-motion";
 import { useAtom } from "jotai";
 import React, { useCallback, useMemo } from "react";
 import { useTranslation } from "react-i18next";
+import i18n from "../../locales";
 import { languageAtom, themeAtom } from "../../store/atoms";
 
 interface AppLayoutProps {
@@ -55,7 +56,10 @@ export const AppLayout: React.FC<AppLayoutProps> = React.memo(
     }, [currentTheme, setTheme]);
 
     const handleLanguageToggle = useCallback(() => {
-      setLanguage(currentLanguage === "ja" ? "en" : "ja");
+      const newLanguage = currentLanguage === "ja" ? "en" : "ja";
+      setLanguage(newLanguage);
+      // i18nextの言語も更新
+      i18n.changeLanguage(newLanguage);
     }, [currentLanguage, setLanguage]);
 
     const menuItems = useMemo(

--- a/src/locales/index.ts
+++ b/src/locales/index.ts
@@ -13,11 +13,26 @@ const resources = {
   },
 };
 
+// localStorageから言語設定を取得
+const getStoredLanguage = (): string => {
+  try {
+    const storedSettings = localStorage.getItem("todo-app-settings");
+    if (storedSettings) {
+      const settings = JSON.parse(storedSettings);
+      return settings.language || "ja";
+    }
+  } catch (error) {
+    console.warn("Failed to read language setting from localStorage:", error);
+  }
+  return "ja";
+};
+
 i18n
   .use(LanguageDetector)
   .use(initReactI18next)
   .init({
     resources,
+    lng: getStoredLanguage(), // 初期言語を設定
     fallbackLng: "ja",
     debug: import.meta.env.DEV,
     interpolation: {
@@ -25,8 +40,8 @@ i18n
     },
     detection: {
       order: ["localStorage", "navigator"],
-      lookupLocalStorage: "todo-app-language",
-      caches: ["localStorage"],
+      lookupLocalStorage: "todo-app-settings",
+      caches: [],
     },
   });
 


### PR DESCRIPTION
## 問題の説明

Issue #6 で報告された、画面右上の言語切り替えボタンをクリックしても言語が切り替わらない問題を修正しました。

## 原因

1. `AppLayout.tsx`で言語の状態（Jotai atom）は変更されていたが、実際のi18nextインスタンスに言語変更が通知されていなかった
2. アプリケーション初期化時に、localStorageに保存された言語設定がi18nextに正しく反映されていなかった

## 修正内容

### 1. AppLayout.tsx の修正
- 言語切り替えボタンクリック時に、Jotai atomの更新に加えて`i18n.changeLanguage()`を呼び出すように修正
- これにより、UI上の言語が即座に切り替わるようになりました

### 2. locales/index.ts の修正
- アプリケーション初期化時にlocalStorageから言語設定を読み取り、i18nextの初期言語として設定
- `getStoredLanguage()`関数を追加して、保存された設定を安全に読み取るように実装

## テスト方法

1. アプリケーションを起動
2. 右上の言語切り替えボタン（地球アイコン）をクリック
3. UI上のテキストが日本語⇔英語で正しく切り替わることを確認
4. ページをリロードしても選択した言語が保持されることを確認

## 関連Issue

Closes #6

## チェックリスト

- [x] コードの変更が問題の根本原因を解決している
- [x] エラーハンドリングが適切に実装されている
- [x] 既存の機能に影響を与えない
- [x] TypeScriptの型エラーがない