### PR TITLE
🐛 fix: タスク詳細画面の編集ボタンが機能しない問題を修正

### DIFF
--- a/src/components/Tasks/TaskDetail.tsx
+++ b/src/components/Tasks/TaskDetail.tsx
@@ -10,13 +10,14 @@ import {
   Card,
   CardContent,
   Chip,
+  Dialog,
   Divider,
   IconButton,
   Typography,
 } from "@mui/material";
 import { useNavigate, useParams } from "@tanstack/react-router";
 import { motion } from "framer-motion";
-import React, { useCallback } from "react";
+import React, { useCallback, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useTasks } from "../../hooks/useTasks";
 import {
@@ -24,12 +25,14 @@ import {
   getPriorityColor,
   getStatusColor,
 } from "../../utils/helpers";
+import { TaskForm } from "./TaskForm";
 
 export const TaskDetail: React.FC = React.memo(() => {
   const { taskId } = useParams({ from: "/tasks/$taskId" });
   const navigate = useNavigate();
   const { t } = useTranslation();
   const { getTaskById, deleteTask, duplicateTask } = useTasks();
+  const [showEditDialog, setShowEditDialog] = useState(false);
 
   const task = taskId ? getTaskById(taskId) : null;
 
@@ -50,6 +53,14 @@ export const TaskDetail: React.FC = React.memo(() => {
   const handleGoBack = useCallback(() => {
     navigate({ to: "/tasks" });
   }, [navigate]);
+
+  const handleEdit = useCallback(() => {
+    setShowEditDialog(true);
+  }, []);
+
+  const handleEditDialogClose = useCallback(() => {
+    setShowEditDialog(false);
+  }, []);
 
   if (!task) {
     return (
@@ -79,9 +90,7 @@ export const TaskDetail: React.FC = React.memo(() => {
           <Button
             startIcon={<EditIcon />}
             variant="outlined"
-            onClick={() => {
-              // TODO: Open edit dialog
-            }}
+            onClick={handleEdit}
           >
             {t("task.editTask")}
           </Button>
@@ -206,6 +215,19 @@ export const TaskDetail: React.FC = React.memo(() => {
             </Box>
           </CardContent>
         </Card>
+
+        <Dialog
+          open={showEditDialog}
+          onClose={handleEditDialogClose}
+          maxWidth="sm"
+          fullWidth
+        >
+          <TaskForm
+            task={task}
+            onClose={handleEditDialogClose}
+            onSuccess={handleEditDialogClose}
+          />
+        </Dialog>
       </Box>
     </motion.div>
   );


### PR DESCRIPTION
## 問題の概要
タスク詳細画面の編集ボタンが機能せず、TODOコメントのまま実装が未完了でした。

## 修正内容
- TaskDetail.tsxの編集ボタンにTODOコメントが残っていた問題を解決
- 編集ダイアログの状態管理（useState）を追加
- TaskFormコンポーネントを使用した編集ダイアログを実装
- 必要なインポート（Dialog, useState, TaskForm）を追加
- イベントハンドラー（handleEdit, handleEditDialogClose）を実装

## 動作確認
- ✅ タスクリストからの編集機能（既存）
- ✅ タスク詳細画面からの編集機能（今回修正）
- ✅ 編集フォームでの各項目の更新
- ✅ 編集後のデータ保存

## 関連ファイル
- `src/components/Tasks/TaskDetail.tsx`

## テスト方法
1. タスク一覧画面でタスクを選択
2. タスク詳細画面に遷移
3. 「編集」ボタンをクリック
4. 編集ダイアログが表示されることを確認
5. 各項目を変更して保存
6. 変更が正常に反映されることを確認

## 変更差分
- TaskDetail.tsxに26行追加、4行削除
- 編集機能の完全な実装により、ユーザビリティが向上