### PR TITLE
fix: resolve update-version workflow branch push issue

### DIFF
--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -15,6 +15,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          ref: main
+          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -37,5 +39,9 @@ jobs:
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
           git add package.json
-          git commit -m "chore: update version to ${{ steps.version.outputs.version }}" || exit 0
-          git push origin main
+          if git diff --staged --quiet; then
+            echo "No changes to commit"
+          else
+            git commit -m "chore: update version to ${{ steps.version.outputs.version }}"
+            git push origin HEAD:main
+          fi


### PR DESCRIPTION
## 問題の概要
`update-version.yml` ワークフローで以下のエラーが発生していました：

```
[detached HEAD 420c78b] chore: update version to 0.1.1
 1 file changed, 9 insertions(+), 2 deletions(-)
error: src refspec main does not match any
error: failed to push some refs to 'https://github.com/tHyt-lab/todo-app-with-agent'
```

## 原因
1. **Detached HEAD状態**: GitHub Actionsがリリースタグをチェックアウトする際、特定のコミットを指すためdetached HEAD状態になっていた
2. **mainブランチの参照エラー**: detached HEAD状態では `git push origin main` が失敗する

## 修正内容

### 1. チェックアウト設定の改善
- `ref: main` を追加してmainブランチを明示的にチェックアウト
- `fetch-depth: 0` を追加して完全な履歴を取得

### 2. プッシュコマンドの修正
- `git push origin main` から `git push origin HEAD:main` に変更
- detached HEAD状態でも正常に動作するように修正

### 3. エラーハンドリングの改善
- 変更がない場合の条件分岐を追加
- より堅牢なワークフローに改善

## テスト
この修正により、次回リリースタグが作成された際にワークフローが正常に動作し、`package.json` のバージョンが自動的に更新されるはずです。

## 関連Issue
- GitHub Actions workflow failure on version update